### PR TITLE
Fix duplicate PR checklists bug, refactor `TrelloPoster`

### DIFF
--- a/lib/trello_poster.rb
+++ b/lib/trello_poster.rb
@@ -1,8 +1,8 @@
 require "trello"
 
 class TrelloPoster
-  def initialize
-    @client = Trello::Client.new(
+  def initialize(client = nil)
+    @client = client || Trello::Client.new(
       developer_public_key: ENV["TRELLO_PUBLIC_KEY"],
       member_token: ENV["TRELLO_MEMBER_TOKEN"],
     )
@@ -11,12 +11,9 @@ class TrelloPoster
   def post!(pr_url, trello_card_id, pr_closed)
     trello_card = client.find(:card, trello_card_id)
     pr_checklist = find_or_create_pr_checklist(trello_card)
+    item = find_or_create_checklist_item(pr_checklist, pr_url)
 
-    if find_pr_on_checklist(pr_checklist, pr_url).nil?
-      pr_checklist.add_item(pr_url, false, "bottom")
-    end
-
-    mark_as_complete(trello_card, pr_url) if pr_closed
+    mark_as_complete(pr_checklist, item) if pr_closed
   end
 
 private
@@ -24,22 +21,17 @@ private
   attr_reader :client
 
   def find_or_create_pr_checklist(trello_card)
-    trello_card
-      .checklists
-      .find { |c| ["pull requests", "prs"].include? c.name.downcase }
-      .then { |c| c || client.create(:checklist, "name" => "Pull Requests", "idCard" => trello_card.id) }
+    trello_card.checklists.find { |c| ["pull requests", "prs"].include? c.name.downcase } ||
+      client.create(:checklist, "name" => "Pull Requests", "idCard" => trello_card.id)
   end
 
-  def mark_as_complete(trello_card, pr_url)
-    checklist = find_or_create_pr_checklist(trello_card)
-    item = find_pr_on_checklist(checklist, pr_url)
-    unless item.nil?
-      checklist.update_item_state(item["id"], "complete")
-      checklist.save
-    end
+  def find_or_create_checklist_item(checklist, pr_url)
+    checklist.check_items.find { |item| item["name"].include? pr_url } ||
+      checklist.add_item(pr_url, false, "bottom")
   end
 
-  def find_pr_on_checklist(checklist, pr_url)
-    checklist.check_items.find { |item| item["name"].include? pr_url }
+  def mark_as_complete(checklist, item)
+    checklist.update_item_state(item["id"], "complete")
+    checklist.save
   end
 end

--- a/lib/trello_poster.rb
+++ b/lib/trello_poster.rb
@@ -26,7 +26,7 @@ private
   def find_or_create_pr_checklist(trello_card)
     trello_card
       .checklists
-      .find { |c| ["pull requests", "prs"].include? c }
+      .find { |c| ["pull requests", "prs"].include? c.name.downcase }
       .then { |c| c || client.create(:checklist, "name" => "Pull Requests", "idCard" => trello_card.id) }
   end
 

--- a/spec/trello_poster_spec.rb
+++ b/spec/trello_poster_spec.rb
@@ -1,137 +1,70 @@
 require "trello_poster"
 
 describe TrelloPoster do
-  subject(:trello_poster) { described_class.new }
+  subject(:trello_poster) { described_class.new client }
 
-  let(:trello_client) do
-    instance_double Trello::Client,
-                    find: trello_card_no_checklist,
-                    create: pull_request_checklist
-  end
+  let(:client) { instance_double Trello::Client }
+  let(:pr_url) { "https://github.com/foo/bar" }
+  let(:trello_card_id) { "123456" }
+  let(:trello_card) { instance_double Trello::Card, id: trello_card_id, checklists: }
+  let(:unrelated_checklist) { instance_double Trello::Checklist, name: "Acceptance criteria", check_items: [] }
+  let(:pr_checklist) { instance_double Trello::Checklist, name: "Pull Requests", check_items: }
+  let(:checklists) { [unrelated_checklist, pr_checklist] }
+  let(:check_item_id) { "123" }
+  let(:check_item) { { "id" => check_item_id, "name" => pr_url } }
+  let(:check_items) { [check_item] }
+  let(:pr_closed) { false }
 
-  let(:another_checklist) do
-    instance_double("Trello::Checklist",
-                    { id: "1",
-                      name: "A checklist",
-                      check_items: [
-                        { "state" => "incomplete",
-                          "id" => "1",
-                          "name" => "An item" },
-                      ],
-                      card_id: "1" })
-  end
-
-  let(:pull_request_checklist) do
-    instance_double("Trello::Checklist",
-                    { id: "2",
-                      name: "Pull Requests",
-                      check_items: [
-                        { "state" => "incomplete",
-                          "id" => "1",
-                          "name" => "https://github.com/gov-test-org/project-a/pull/1 - Add the UI to frontend" },
-                      ],
-                      card_id: "1" })
-  end
-
-  let(:card_checklists) { [another_checklist, pull_request_checklist] }
-
-  let(:trello_card) do
-    instance_double("Trello::Card",
-                    checklists: card_checklists,
-                    id: "abcd1234")
-  end
-
-  let(:trello_card_no_checklist) do
-    instance_double("Trello::Card",
-                    checklists: [],
-                    id: "efgh5678")
+  def post!
+    trello_poster.post! pr_url, trello_card_id, pr_closed
   end
 
   before do
-    allow(Trello::Client).to receive(:new).and_return(trello_client)
+    allow(client).to receive(:find)
+      .with(:card, trello_card_id)
+      .and_return(trello_card)
   end
 
-  context "when a Trello card contains a 'Pull Requests' checklist" do
-    before do
-      allow(trello_client).to receive(:find).and_return(trello_card)
-      allow(pull_request_checklist).to receive(:add_item)
-        .with("https://github.com/gov-test-org/project-a/pull/2", false, "bottom")
-    end
-
-    context "and trello_card_id is valid" do
-      it "finds the Trello card via the Trello API" do
-        allow(trello_client).to receive(:find).and_return(trello_card)
-
-        trello_poster.post!(
-          "https://github.com/gov-test-org/project-a/pull/2", "abcd1234", false
-        )
-      end
-
-      it "posts the GitHub PR URL to the 'Pull Requests' checklist" do
-        expect(pull_request_checklist).to receive(:add_item)
-
-        trello_poster.post!(
-          "https://github.com/gov-test-org/project-a/pull/2", "abcd1234", false
-        )
-      end
-
-      it "does not post the GitHub PR URL to checklist that is not called 'Pull Requests'" do
-        expect(another_checklist).not_to receive(:add_item)
-
-        trello_poster.post!(
-          "https://github.com/gov-test-org/project-a/pull/2", "abcd1234", false
-        )
-      end
-
-      it "does not post the GitHub PR URL more than once" do
-        expect(pull_request_checklist).not_to receive(:add_item)
-
-        trello_poster.post!(
-          "https://github.com/gov-test-org/project-a/pull/1", "abcd1234", false
-        )
-      end
-    end
-
-    context "and pr_closed is true" do
-      before do
-        allow(pull_request_checklist).to receive(:update_item_state)
-        allow(pull_request_checklist).to receive(:save)
-      end
-
-      it "checks off the pull request on the checklist" do
-        expect(pull_request_checklist).to receive(:update_item_state)
-
-        trello_poster.post!(
-          "https://github.com/gov-test-org/project-a/pull/1", "abcd1234", true
-        )
-      end
-    end
-
-    context "and pr_closed is false" do
-      it "does not check off the pull request on the checklist" do
-        expect(pull_request_checklist).not_to receive(:update_item_state)
-
-        trello_poster.post!(
-          "https://github.com/gov-test-org/project-a/pull/2", "abcd1234", false
-        )
-      end
+  context "when the Trello card already contains a link to the PR, and the PR is not closed" do
+    it "does nothing" do
+      post!
     end
   end
 
-  context "when a Trello card does not contain a 'Pull Requests' checklist" do
-    before do
-      allow(trello_client)
-        .to receive(:find).and_return(trello_card_no_checklist)
-      allow(pull_request_checklist).to receive(:add_item)
-        .with("https://github.com/gov-test-org/project-a/pull/2", false, "bottom")
+  context "when there is no existing PR checklist" do
+    let(:checklists) { [unrelated_checklist] }
+
+    it "creates a new checklist" do
+      expect(client).to receive(:create)
+        .once
+        .with(:checklist, { "idCard" => trello_card_id, "name" => "Pull Requests" })
+        .and_return(pr_checklist)
+
+      post!
     end
+  end
 
-    it "creates a checklist via the Trello API" do
-      allow(trello_client).to receive(:create).and_return(pull_request_checklist)
+  context "when there is no matching item on the PR checklist" do
+    let(:check_items) { [{ "name" => "https://github.com/some/other/pr" }] }
 
-      trello_poster.post!(
-        "https://github.com/gov-test-org/project-a/pull/2", "efgh5678", false
-      )
+    it "adds a checklist item for the PR" do
+      expect(pr_checklist).to receive(:add_item)
+        .once
+        .with(pr_url, false, "bottom")
+        .and_return(check_item)
+
+      post!
+    end
+  end
+
+  context "when the PR is closed" do
+    let(:pr_closed) { true }
+
+    it "marks the item as complete" do
+      expect(pr_checklist).to receive(:update_item_state).with(check_item_id, "complete").once
+      expect(pr_checklist).to receive(:save).once
+
+      post!
     end
   end
 end


### PR DESCRIPTION
Fixes a bug introduced in 1bce5a8, which caused duplicate PR checklists to be added to cards.

Also further simplifies `TrelloPoster` and rewrites its specs.